### PR TITLE
artf4153 Adds HAL structure memory management

### DIFF
--- a/hal/include/HAL/Analog.hpp
+++ b/hal/include/HAL/Analog.hpp
@@ -14,12 +14,14 @@ extern "C"
 {
 	// Analog output functions
 	void* initializeAnalogOutputPort(void* port_pointer, int32_t *status);
+	void freeAnalogOutputPort(void* analog_port_pointer);
 	void setAnalogOutput(void* analog_port_pointer, double voltage, int32_t *status);
 	double getAnalogOutput(void* analog_port_pointer, int32_t *status);
 	bool checkAnalogOutputChannel(uint32_t pin);
 
 	// Analog input functions
 	void* initializeAnalogInputPort(void* port_pointer, int32_t *status);
+	void freeAnalogInputPort(void* analog_port_pointer);
 	bool checkAnalogModule(uint8_t module);
 	bool checkAnalogInputChannel(uint32_t pin);
 

--- a/hal/include/HAL/Digital.hpp
+++ b/hal/include/HAL/Digital.hpp
@@ -16,6 +16,7 @@ priority_recursive_mutex& spiGetSemaphore(uint8_t port);
 extern "C"
 {
 	void* initializeDigitalPort(void* port_pointer, int32_t *status);
+	void freeDigitalPort(void* digital_port_pointer);
 	bool checkPWMChannel(void* digital_port_pointer);
 	bool checkRelayChannel(void* digital_port_pointer);
 

--- a/hal/include/HAL/HAL.hpp
+++ b/hal/include/HAL/HAL.hpp
@@ -211,6 +211,7 @@ extern "C"
 
 	void* getPort(uint8_t pin);
 	void* getPortWithModule(uint8_t module, uint8_t pin);
+	void freePort(void* port);
 	const char* getHALErrorMessage(int32_t code);
 
 	uint16_t getFPGAVersion(int32_t *status);

--- a/hal/include/HAL/Solenoid.hpp
+++ b/hal/include/HAL/Solenoid.hpp
@@ -5,6 +5,7 @@
 extern "C"
 {
 	void* initializeSolenoidPort(void* port_pointer, int32_t *status);
+	void freeSolenoidPort(void* solenoid_port_pointer);
 	bool checkSolenoidModule(uint8_t module);
 
 	bool getSolenoid(void* solenoid_port_pointer, int32_t *status);

--- a/hal/lib/Athena/Analog.cpp
+++ b/hal/lib/Athena/Analog.cpp
@@ -71,6 +71,13 @@ void* initializeAnalogInputPort(void* port_pointer, int32_t *status) {
   return analog_port;
 }
 
+void freeAnalogInputPort(void* analog_port_pointer)
+{
+  AnalogPort* port = (AnalogPort*) analog_port_pointer;
+  delete port->accumulator;
+  delete port;
+}
+
 /**
  * Initialize the analog output port using the given port object.
  */
@@ -81,7 +88,15 @@ void* initializeAnalogOutputPort(void* port_pointer, int32_t *status) {
   // Initialize port structure
   AnalogPort* analog_port = new AnalogPort();
   analog_port->port = *port;
+  analog_port->accumulator = NULL;
   return analog_port;
+}
+
+void freeAnalogOutputPort(void* analog_port_pointer)
+{
+  AnalogPort* port = (AnalogPort*) analog_port_pointer;
+  delete port->accumulator;
+  delete port;
 }
 
 
@@ -596,6 +611,7 @@ void cleanAnalogTrigger(void* analog_trigger_pointer, int32_t *status) {
   AnalogTrigger* trigger = (AnalogTrigger*) analog_trigger_pointer;
   triggers->Free(trigger->index);
   delete trigger->trigger;
+  freeAnalogInputPort(trigger->port);
   delete trigger;
 }
 

--- a/hal/lib/Athena/Digital.cpp
+++ b/hal/lib/Athena/Digital.cpp
@@ -150,6 +150,12 @@ void* initializeDigitalPort(void* port_pointer, int32_t *status) {
   return digital_port;
 }
 
+void freeDigitalPort(void* digital_port_pointer)
+{
+  DigitalPort* port = (DigitalPort*) digital_port_pointer;
+  delete port;
+}
+
 bool checkPWMChannel(void* digital_port_pointer) {
   DigitalPort* port = (DigitalPort*) digital_port_pointer;
   return port->port.pin < kPwmPins;

--- a/hal/lib/Athena/HALAthena.cpp
+++ b/hal/lib/Athena/HALAthena.cpp
@@ -41,6 +41,12 @@ void* getPortWithModule(uint8_t module, uint8_t pin)
 	return port;
 }
 
+void freePort(void* port_pointer)
+{
+	Port* port = (Port*) port_pointer;
+	delete port;
+}
+
 const char* getHALErrorMessage(int32_t code)
 {
 	switch(code) {

--- a/hal/lib/Athena/Solenoid.cpp
+++ b/hal/lib/Athena/Solenoid.cpp
@@ -33,6 +33,12 @@ void* initializeSolenoidPort(void *port_pointer, int32_t *status) {
 	return solenoid_port;
 }
 
+void freeSolenoidPort(void* solenoid_port_pointer)
+{
+	solenoid_port_t* port = (solenoid_port_t*) solenoid_port_pointer;
+	delete port;
+}
+
 bool checkSolenoidModule(uint8_t module) {
 	return module < NUM_MODULE_NUMBERS;
 }

--- a/wpilibc/Athena/src/AnalogInput.cpp
+++ b/wpilibc/Athena/src/AnalogInput.cpp
@@ -55,7 +55,11 @@ AnalogInput::AnalogInput(uint32_t channel) {
 /**
  * Channel destructor.
  */
-AnalogInput::~AnalogInput() { inputs->Free(m_channel); }
+AnalogInput::~AnalogInput() 
+  { 
+    freeAnalogInputPort(m_port);
+    inputs->Free(m_channel);
+  }
 
 /**
  * Get a sample straight from this channel.

--- a/wpilibc/Athena/src/AnalogOutput.cpp
+++ b/wpilibc/Athena/src/AnalogOutput.cpp
@@ -50,7 +50,11 @@ AnalogOutput::AnalogOutput(uint32_t channel) {
 /**
  * Destructor. Frees analog output resource
  */
-AnalogOutput::~AnalogOutput() { outputs->Free(m_channel); }
+AnalogOutput::~AnalogOutput() 
+  {
+    freeAnalogOutputPort(m_port);
+    outputs->Free(m_channel); 
+  }
 
 /**
  * Set the value of the analog output

--- a/wpilibj/src/athena/cpp/lib/AnalogJNI.cpp
+++ b/wpilibj/src/athena/cpp/lib/AnalogJNI.cpp
@@ -35,6 +35,18 @@ JNIEXPORT jlong JNICALL Java_edu_wpi_first_wpilibj_hal_AnalogJNI_initializeAnalo
 
 /*
  * Class:     edu_wpi_first_wpilibj_hal_AnalogJNI
+ * Method:    freeAnalogInputPort
+ * Signature: (J)V
+ */
+JNIEXPORT void JNICALL Java_edu_wpi_first_wpilibj_hal_AnalogJNI_freeAnalogInputPort
+  (JNIEnv * env, jclass, jlong id)
+{
+	ANALOGJNI_LOG(logDEBUG) << "Port Ptr = " << (void*)id;
+	freeAnalogInputPort((void*)id);
+}
+
+/*
+ * Class:     edu_wpi_first_wpilibj_hal_AnalogJNI
  * Method:    initializeAnalogOutputPort
  * Signature: (J)J
  */
@@ -48,6 +60,18 @@ JNIEXPORT jlong JNICALL Java_edu_wpi_first_wpilibj_hal_AnalogJNI_initializeAnalo
 	ANALOGJNI_LOG(logDEBUG) << "Analog Ptr = " << analog;
 	CheckStatus(env, status);
 	return (jlong)analog;
+}
+
+/*
+ * Class:     edu_wpi_first_wpilibj_hal_AnalogJNI
+ * Method:    freeAnalogOutputPort
+ * Signature: (J)V
+ */
+JNIEXPORT void JNICALL Java_edu_wpi_first_wpilibj_hal_AnalogJNI_freeAnalogOutputPort
+  (JNIEnv * env, jclass, jlong id)
+{
+	ANALOGJNI_LOG(logDEBUG) << "Port Ptr = " << (void*)id;
+	freeAnalogOutputPort((void*)id);
 }
 
 /*

--- a/wpilibj/src/athena/cpp/lib/DIOJNI.cpp
+++ b/wpilibj/src/athena/cpp/lib/DIOJNI.cpp
@@ -35,6 +35,19 @@ JNIEXPORT jlong JNICALL Java_edu_wpi_first_wpilibj_hal_DIOJNI_initializeDigitalP
 }
 
 /*
+* Class:     edu_wpi_first_wpilibj_hal_DIOJNI
+* Method:    freeDigitalPort
+* Signature: (J)V;
+*/
+JNIEXPORT void JNICALL Java_edu_wpi_first_wpilibj_hal_DIOJNI_freeDigitalPort
+(JNIEnv * env, jclass, jlong id)
+{
+ DIOJNI_LOG(logDEBUG) << "Calling DIOJNI freeDigitalPort";
+ DIOJNI_LOG(logDEBUG) << "Port Ptr = " << (void*)id;
+ freeDigitalPort((void*)id);
+}
+
+/*
  * Class:     edu_wpi_first_wpilibj_hal_DIOJNI
  * Method:    allocateDIO
  * Signature: (JZ)Z

--- a/wpilibj/src/athena/cpp/lib/JNIWrapper.cpp
+++ b/wpilibj/src/athena/cpp/lib/JNIWrapper.cpp
@@ -40,4 +40,19 @@ JNIEXPORT jlong JNICALL Java_edu_wpi_first_wpilibj_hal_JNIWrapper_getPort
 	return (jlong)port;
 }
 
+/*
+ * Class:     edu_wpi_first_wpilibj_hal_JNIWrapper
+ * Method:    freePort
+ * Signature: (J)V
+ */
+JNIEXPORT void JNICALL Java_edu_wpi_first_wpilibj_hal_JNIWrapper_freePort
+  (JNIEnv * env, jclass, jlong id)
+{
+	//FILE_LOG(logDEBUG) << "Calling JNIWrapper getPortWithModlue";
+	//FILE_LOG(logDEBUG) << "Module = " << (jint)module;
+	//FILE_LOG(logDEBUG) << "Pin = " << (jint)pin;
+	freePort((void*)id);
+	//FILE_LOG(logDEBUG) << "Port Ptr = " << port;
+}
+
 }  // extern "C"

--- a/wpilibj/src/athena/cpp/lib/SolenoidJNI.cpp
+++ b/wpilibj/src/athena/cpp/lib/SolenoidJNI.cpp
@@ -43,6 +43,20 @@ JNIEXPORT jlong JNICALL Java_edu_wpi_first_wpilibj_hal_SolenoidJNI_initializeSol
 
 /*
  * Class:     edu_wpi_first_wpilibj_hal_SolenoidJNI
+ * Method:    freeSolenoidPort
+ * Signature: (J)V
+ */
+JNIEXPORT void JNICALL Java_edu_wpi_first_wpilibj_hal_SolenoidJNI_freeSolenoidPort
+  (JNIEnv *env, jclass, jlong id)
+{
+	SOLENOIDJNI_LOG(logDEBUG) << "Calling SolenoidJNI initializeSolenoidPort";
+
+	SOLENOIDJNI_LOG(logDEBUG) << "Port Ptr = " << (void*)id;
+	freeSolenoidPort((void*)id);
+}
+
+/*
+ * Class:     edu_wpi_first_wpilibj_hal_SolenoidJNI
  * Method:    getPortWithModule
  * Signature: (BB)J
  */

--- a/wpilibj/src/athena/java/edu/wpi/first/wpilibj/AnalogInput.java
+++ b/wpilibj/src/athena/java/edu/wpi/first/wpilibj/AnalogInput.java
@@ -77,6 +77,8 @@ public class AnalogInput extends SensorBase implements PIDSource, LiveWindowSend
    * Channel destructor.
    */
   public void free() {
+	AnalogJNI.freeAnalogInputPort(m_port);
+	m_port = 0;
     channels.free(m_channel);
     m_channel = 0;
     m_accumulatorOffset = 0;

--- a/wpilibj/src/athena/java/edu/wpi/first/wpilibj/AnalogOutput.java
+++ b/wpilibj/src/athena/java/edu/wpi/first/wpilibj/AnalogOutput.java
@@ -52,6 +52,8 @@ public class AnalogOutput extends SensorBase implements LiveWindowSendable {
    * Channel destructor.
    */
   public void free() {
+	AnalogJNI.freeAnalogOutputPort(m_port);
+	m_port = 0;
     channels.free(m_channel);
     m_channel = 0;
   }

--- a/wpilibj/src/athena/java/edu/wpi/first/wpilibj/DigitalSource.java
+++ b/wpilibj/src/athena/java/edu/wpi/first/wpilibj/DigitalSource.java
@@ -47,6 +47,8 @@ public abstract class DigitalSource extends InterruptableSensorBase {
   public void free() {
     channels.free(m_channel);
     DIOJNI.freeDIO(m_port);
+	DIOJNI.freeDigitalPort(m_port);
+	m_port = 0;
     m_channel = 0;
   }
 

--- a/wpilibj/src/athena/java/edu/wpi/first/wpilibj/DoubleSolenoid.java
+++ b/wpilibj/src/athena/java/edu/wpi/first/wpilibj/DoubleSolenoid.java
@@ -100,6 +100,7 @@ public class DoubleSolenoid extends SolenoidBase implements LiveWindowSendable {
   public synchronized void free() {
     m_allocated.free(m_moduleNumber * kSolenoidChannels + m_forwardChannel);
     m_allocated.free(m_moduleNumber * kSolenoidChannels + m_reverseChannel);
+	super.free();
   }
 
   /**

--- a/wpilibj/src/athena/java/edu/wpi/first/wpilibj/PWM.java
+++ b/wpilibj/src/athena/java/edu/wpi/first/wpilibj/PWM.java
@@ -143,6 +143,8 @@ public class PWM extends SensorBase implements LiveWindowSendable {
     PWMJNI.setPWM(m_port, (short) 0);
     PWMJNI.freePWMChannel(m_port);
     PWMJNI.freeDIO(m_port);
+	DIOJNI.freeDigitalPort(m_port);
+	m_port = 0;
   }
 
   /**

--- a/wpilibj/src/athena/java/edu/wpi/first/wpilibj/Relay.java
+++ b/wpilibj/src/athena/java/edu/wpi/first/wpilibj/Relay.java
@@ -178,6 +178,9 @@ public class Relay extends SensorBase implements MotorSafety, LiveWindowSendable
     RelayJNI.setRelayReverse(m_port, false);
 
     DIOJNI.freeDIO(m_port);
+	
+	DIOJNI.freeDigitalPort(m_port);
+	m_port = 0;
   }
 
   /**

--- a/wpilibj/src/athena/java/edu/wpi/first/wpilibj/Solenoid.java
+++ b/wpilibj/src/athena/java/edu/wpi/first/wpilibj/Solenoid.java
@@ -70,7 +70,10 @@ public class Solenoid extends SolenoidBase implements LiveWindowSendable {
    */
   public synchronized void free() {
     // m_allocated.free((m_moduleNumber - 1) * kSolenoidChannels + m_channel -
-    // 1);
+    // 1); 
+	SolenoidJNI.freeSolenoidPort(m_solenoid_port);
+	m_solenoid_port = 0;
+	super.free();
   }
 
   /**

--- a/wpilibj/src/athena/java/edu/wpi/first/wpilibj/SolenoidBase.java
+++ b/wpilibj/src/athena/java/edu/wpi/first/wpilibj/SolenoidBase.java
@@ -33,6 +33,17 @@ public abstract class SolenoidBase extends SensorBase {
       m_ports[i] = SolenoidJNI.initializeSolenoidPort(port);
     }
   }
+  
+  /**
+   * Free the resources associated with by the solenoid base.
+   */
+  @Override
+  public void free() {
+    for (int i = 0; i < m_ports.length; i++) {
+	  SolenoidJNI.freeSolenoidPort(m_ports[i]);
+	  m_ports[i] = 0;
+	}
+  } 
 
   /**
    * Set the value of a solenoid.

--- a/wpilibj/src/athena/java/edu/wpi/first/wpilibj/hal/AnalogJNI.java
+++ b/wpilibj/src/athena/java/edu/wpi/first/wpilibj/hal/AnalogJNI.java
@@ -33,8 +33,12 @@ public class AnalogJNI extends JNIWrapper {
   };
 
   public static native long initializeAnalogInputPort(long port_pointer);
+  
+  public static native void freeAnalogInputPort(long port_pointer);
 
   public static native long initializeAnalogOutputPort(long port_pointer);
+  
+  public static native void freeAnalogOutputPort(long port_pointer);
 
   public static native boolean checkAnalogModule(byte module);
 

--- a/wpilibj/src/athena/java/edu/wpi/first/wpilibj/hal/DIOJNI.java
+++ b/wpilibj/src/athena/java/edu/wpi/first/wpilibj/hal/DIOJNI.java
@@ -2,6 +2,8 @@ package edu.wpi.first.wpilibj.hal;
 
 public class DIOJNI extends JNIWrapper {
   public static native long initializeDigitalPort(long port_pointer);
+  
+  public static native void freeDigitalPort(long port_pointer);
 
   public static native boolean allocateDIO(long digital_port_pointer, boolean input);
 

--- a/wpilibj/src/athena/java/edu/wpi/first/wpilibj/hal/JNIWrapper.java
+++ b/wpilibj/src/athena/java/edu/wpi/first/wpilibj/hal/JNIWrapper.java
@@ -51,4 +51,6 @@ public class JNIWrapper {
   public static native long getPortWithModule(byte module, byte pin);
 
   public static native long getPort(byte pin);
+  
+  public static native void freePort(long port_pointer);
 }

--- a/wpilibj/src/athena/java/edu/wpi/first/wpilibj/hal/SolenoidJNI.java
+++ b/wpilibj/src/athena/java/edu/wpi/first/wpilibj/hal/SolenoidJNI.java
@@ -2,6 +2,8 @@ package edu.wpi.first.wpilibj.hal;
 
 public class SolenoidJNI extends JNIWrapper {
   public static native long initializeSolenoidPort(long portPointer);
+  
+  public static native void freeSolenoidPort(long port_pointer);
 
   public static native long getPortWithModule(byte module, byte channel);
 


### PR DESCRIPTION
The reason this is here is that I'm still trying to get permissions to push to the official repository, but I still can't get a response from FIRST, and I thought I remembered Peter saying if someone created a pull request here you guys would try and commit it to the official repository. This is one of the trackers I created earlier in the year and am trying to fix.

In the current HAL, once the port structures were created, there was no
way to free the structures. The way the C++ libraries were written this
wasn't a problem, since it grabbed a copy of each and stored them in an
array on bootup. However java does not do this, and grabs new ports
every time an object is created. This causes memory leaks if an object
is ever disposed in java. The same thing looks to be happening in
python, and C# does it too currently, but that would change if this gets
merged.

This does not include the fixes to WPILibJ, just the HAL.