### PR TITLE
Adds new CanTalon HAL Functions to C library

### DIFF
--- a/hal/include/HAL/CanTalonSRX.h
+++ b/hal/include/HAL/CanTalonSRX.h
@@ -411,6 +411,11 @@ extern "C" {
 	CTR_Code c_TalonSRX_SetProfileSlotSelect(void *handle, int param);
 	CTR_Code c_TalonSRX_SetRampThrottle(void *handle, int param);
 	CTR_Code c_TalonSRX_SetRevFeedbackSensor(void *handle, int param);
+	CTR_Code c_TalonSRX_GetPulseWidthPosition(void *handle, int *param);
+	CTR_Code c_TalonSRX_GetPulseWidthVelocity(void *handle, int *param);
+	CTR_Code c_TalonSRX_GetPulseWidthRiseToFallUs(void *handle, int *param);
+	CTR_Code c_TalonSRX_GetPulseWidthRiseToRiseUs(void *handle, int *param);
+	CTR_Code c_TalonSRX_IsPulseWidthSensorPresent(void *handle, int *param);
 }
 #endif
 

--- a/hal/lib/Athena/ctre/CanTalonSRX.cpp
+++ b/hal/lib/Athena/ctre/CanTalonSRX.cpp
@@ -1394,4 +1394,24 @@ CTR_Code c_TalonSRX_SetRevFeedbackSensor(void *handle, int param)
 {
 	return ((CanTalonSRX*)handle)->SetRevFeedbackSensor(param);
 }
+CTR_Code c_TalonSRX_GetPulseWidthPosition(void *handle, int *param)
+{
+	return ((CanTalonSRX*)handle)->GetPulseWidthPosition(*param);
+}
+CTR_Code c_TalonSRX_GetPulseWidthVelocity(void *handle, int *param)
+{
+	return ((CanTalonSRX*)handle)->GetPulseWidthVelocity(*param);
+}
+CTR_Code c_TalonSRX_GetPulseWidthRiseToFallUs(void *handle, int *param)
+{
+	return ((CanTalonSRX*)handle)->GetPulseWidthRiseToFallUs(*param);
+}
+CTR_Code c_TalonSRX_GetPulseWidthRiseToRiseUs(void *handle, int *param)
+{
+	return ((CanTalonSRX*)handle)->GetPulseWidthRiseToRiseUs(*param);
+}
+CTR_Code c_TalonSRX_IsPulseWidthSensorPresent(void *handle, int *param)
+{
+	return ((CanTalonSRX*)handle)->IsPulseWidthSensorPresent(*param);
+}
 }


### PR DESCRIPTION
New functions were added to CanTalonSRX in the HAL, however they were
not added to the C side of the library.

There was no enum values added for these functions, so they cannot be gotten using GetParamResponse. I'm guessing you guys will need this as well for python.