### PR TITLE
Add an "extern C" function to get the native condition_variable

### DIFF
--- a/hal/include/HAL/Semaphore.hpp
+++ b/hal/include/HAL/Semaphore.hpp
@@ -20,5 +20,7 @@ extern "C"
 	void deleteMultiWait(MULTIWAIT_ID sem);
 	void takeMultiWait(MULTIWAIT_ID sem, MUTEX_ID m);
 	void giveMultiWait(MULTIWAIT_ID sem);
+	
+	NATIVE_MULTIWAIT_ID getNativeHandle(MULTIWAIT_ID sem);
 }
 

--- a/hal/lib/Athena/Semaphore.cpp
+++ b/hal/lib/Athena/Semaphore.cpp
@@ -40,3 +40,5 @@ void takeMultiWait(MULTIWAIT_ID cond, MUTEX_ID m) {
 }
 
 void giveMultiWait(MULTIWAIT_ID cond) { cond->notify_all(); }
+
+NATIVE_MULTIWAIT_ID getNativeHandle(MULTIWAIT_ID cond) { return cond->native_handle(); }


### PR DESCRIPTION
This function will allow robotpy and RobotDotNet to fix our issues RobotDotNet/WPILib#67 and robotpy/robotpy-wpilib#156 by giving us ways to get the native handle for the multiwait primitives.