### PR TITLE
Makes HALSetDataSem take a MULTIWAIT_ID rather then a NATIVE_MULTIWAIT_ID

### DIFF
--- a/hal/include/HAL/HAL.hpp
+++ b/hal/include/HAL/HAL.hpp
@@ -234,7 +234,7 @@ extern "C"
 	int HALSetJoystickOutputs(uint8_t joystickNum, uint32_t outputs, uint16_t leftRumble, uint16_t rightRumble);
 	int HALGetMatchTime(float *matchTime);
 
-	void HALSetNewDataSem(NATIVE_MULTIWAIT_ID sem);
+	void HALSetNewDataSem(MULTIWAIT_ID sem);
 
 	bool HALGetSystemActive(int32_t *status);
 	bool HALGetBrownedOut(int32_t *status);

--- a/hal/include/HAL/Semaphore.hpp
+++ b/hal/include/HAL/Semaphore.hpp
@@ -1,24 +1,21 @@
 #pragma once
 
-#include <stdint.h>
-#include <mutex>
-#include <condition_variable>
+#include "cpp/priority_condition_variable.h"
+#include "cpp/priority_mutex.h"
 
-typedef std::mutex* MUTEX_ID;
-typedef std::condition_variable* MULTIWAIT_ID;
-typedef std::condition_variable::native_handle_type NATIVE_MULTIWAIT_ID;
+typedef priority_mutex* MUTEX_ID;
+typedef priority_condition_variable* MULTIWAIT_ID;
+typedef priority_condition_variable::native_handle_type NATIVE_MULTIWAIT_ID;
 
-extern "C"
-{
-	MUTEX_ID initializeMutexNormal();
-	void deleteMutex(MUTEX_ID sem);
-	void takeMutex(MUTEX_ID sem);
-	bool tryTakeMutex(MUTEX_ID sem);
-	void giveMutex(MUTEX_ID sem);
+extern "C" {
+  MUTEX_ID initializeMutexNormal();
+  void deleteMutex(MUTEX_ID sem);
+  void takeMutex(MUTEX_ID sem);
+  bool tryTakeMutex(MUTEX_ID sem);
+  void giveMutex(MUTEX_ID sem);
 
-	MULTIWAIT_ID initializeMultiWait();
-	void deleteMultiWait(MULTIWAIT_ID sem);
-	void takeMultiWait(MULTIWAIT_ID sem, MUTEX_ID m);
-	void giveMultiWait(MULTIWAIT_ID sem);
+  MULTIWAIT_ID initializeMultiWait();
+  void deleteMultiWait(MULTIWAIT_ID cond);
+  void takeMultiWait(MULTIWAIT_ID cond, MUTEX_ID m);
+  void giveMultiWait(MULTIWAIT_ID cond);
 }
-

--- a/hal/include/HAL/cpp/priority_condition_variable.h
+++ b/hal/include/HAL/cpp/priority_condition_variable.h
@@ -14,10 +14,10 @@
 #include "priority_mutex.h"
 
 class priority_condition_variable {
-  typedef std::condition_variable::native_handle_type native_handle_type;
   typedef std::chrono::system_clock clock_t;
 
  public:
+  typedef std::condition_variable::native_handle_type native_handle_type;
   priority_condition_variable() : m_mutex(std::make_shared<std::mutex>()) {}
   ~priority_condition_variable() = default;
 

--- a/hal/lib/Athena/Semaphore.cpp
+++ b/hal/lib/Athena/Semaphore.cpp
@@ -9,7 +9,7 @@ TLogLevel semaphoreLogLevel = logDEBUG;
     if (level > semaphoreLogLevel) ; \
     else Log().Get(level)
 
-MUTEX_ID initializeMutexNormal() { return new std::mutex; }
+MUTEX_ID initializeMutexNormal() { return new priority_mutex; }
 
 void deleteMutex(MUTEX_ID sem) { delete sem; }
 
@@ -30,12 +30,12 @@ bool tryTakeMutex(MUTEX_ID mutex) { return mutex->try_lock(); }
  */
 void giveMutex(MUTEX_ID mutex) { mutex->unlock(); }
 
-MULTIWAIT_ID initializeMultiWait() { return new std::condition_variable; }
+MULTIWAIT_ID initializeMultiWait() { return new priority_condition_variable; }
 
 void deleteMultiWait(MULTIWAIT_ID cond) { delete cond; }
 
 void takeMultiWait(MULTIWAIT_ID cond, MUTEX_ID m) {
-  std::unique_lock<std::mutex> lock(*m);
+  std::unique_lock<priority_mutex> lock(*m);
   cond->wait(lock);
 }
 

--- a/hal/lib/Shared/HAL.cpp
+++ b/hal/lib/Shared/HAL.cpp
@@ -7,9 +7,9 @@ int HALGetControlWord(HALControlWord *data)
 	return FRC_NetworkCommunication_getControlWord((ControlWord_t*) data);
 }
 
-void HALSetNewDataSem(NATIVE_MULTIWAIT_ID sem)
+void HALSetNewDataSem(MULTIWAIT_ID sem)
 {
-	setNewDataSem(sem);
+	setNewDataSem(sem->native_handle());
 }
 
 int HALGetAllianceStation(enum HALAllianceStationID *allianceStation)

--- a/wpilibc/Athena/src/DriverStation.cpp
+++ b/wpilibc/Athena/src/DriverStation.cpp
@@ -46,7 +46,7 @@ DriverStation::DriverStation() {
   }
   // Register that semaphore with the network communications task.
   // It will signal when new packet data is available.
-  HALSetNewDataSem(m_packetDataAvailableCond.native_handle());
+  HALSetNewDataSem(&m_packetDataAvailableCond);
 
   AddToSingletonList();
 

--- a/wpilibj/src/athena/cpp/lib/FRCNetworkCommunicationsLibrary.cpp
+++ b/wpilibj/src/athena/cpp/lib/FRCNetworkCommunicationsLibrary.cpp
@@ -402,7 +402,7 @@ JNIEXPORT void JNICALL Java_edu_wpi_first_wpilibj_communication_FRCNetworkCommun
   (JNIEnv * env, jclass, jlong id )
 {
 	NETCOMM_LOG(logDEBUG) << "Mutex Ptr = " << (void*)id;
-	HALSetNewDataSem(((MULTIWAIT_ID)id)->native_handle());
+	HALSetNewDataSem(((MULTIWAIT_ID)id));
 }
 
 /*


### PR DESCRIPTION
Having the HAL take a NATIVE_MULTIWAIT_ID without any way to get that
structure from extern "C" code is a problem. This makes it so it just
takes a MULTIWAIT_ID, and then grabs the native handle inside the HAL.